### PR TITLE
Error: Make three-digit run folders standard #20

### DIFF
--- a/examples/mockup/README.md
+++ b/examples/mockup/README.md
@@ -36,9 +36,9 @@ profit collect
 yielding a file `output.txt` with the entries from `run` directories.
 
 To fit results:
-...
+```
 profit fit
-...
+```
 In addition, it generates a file 'profit.hdf5 where the data is stored.
 
 We can view these results in the browser via

--- a/examples/mockup/README.md
+++ b/examples/mockup/README.md
@@ -35,6 +35,12 @@ profit collect
 ```
 yielding a file `output.txt` with the entries from `run` directories.
 
+To fit results:
+...
+profit fit
+...
+In addition, it generates a file 'profit.hdf5 where the data is stored.
+
 We can view these results in the browser via
 ```
 profit ui

--- a/profit/main.py
+++ b/profit/main.py
@@ -136,7 +136,7 @@ def main():
         spec.loader.exec_module(interface)
         data = empty((config['ntrain'], len(config['output'])))
         for krun in range(config['ntrain']):
-            run_dir_single = os.path.join(config['run_dir'], str(krun))
+            run_dir_single = os.path.join(config['run_dir'], str(krun).zfill(3))
             print(run_dir_single)
             try:
                 os.chdir(run_dir_single)

--- a/profit/main.py
+++ b/profit/main.py
@@ -136,7 +136,7 @@ def main():
         spec.loader.exec_module(interface)
         data = empty((config['ntrain'], len(config['output'])))
         for krun in range(config['ntrain']):
-            run_dir_single = os.path.join(config['run_dir'], str(krun).zfill(3))
+            run_dir_single = os.path.join(config['run_dir'], str(krun).zfill(3)) #.zfill(3) is an option that forces krun to have 3 digits
             print(run_dir_single)
             try:
                 os.chdir(run_dir_single)

--- a/profit/post.py
+++ b/profit/post.py
@@ -15,7 +15,7 @@ class Postprocessor:
 #        expansion = orth_ttr(uq.backend.order, distribution)
         
         for krun in range(nrun):
-            fulldir = path.join(config.run_dir, str(krun))
+            fulldir = path.join(config.run_dir, str(krun).zfill(3))
             try:
                 os.chdir(fulldir)
                 self.data[:,krun] = self.interface.get_output()

--- a/profit/post.py
+++ b/profit/post.py
@@ -15,7 +15,7 @@ class Postprocessor:
 #        expansion = orth_ttr(uq.backend.order, distribution)
         
         for krun in range(nrun):
-            fulldir = path.join(config.run_dir, str(krun).zfill(3))
+            fulldir = path.join(config.run_dir, str(krun).zfill(3)) #.zfill(3) is an option that forces krun to have 3 digits
             try:
                 os.chdir(fulldir)
                 self.data[:,krun] = self.interface.get_output()

--- a/profit/pre.py
+++ b/profit/pre.py
@@ -32,7 +32,7 @@ def fill_run_dir(eval_points, template_dir='template/', run_dir='run/',
     write_input(eval_points)
 
     for krun in kruns:
-        run_dir_single = os.path.join(run_dir, str(krun))
+        run_dir_single = os.path.join(run_dir, str(krun).zfill(3))
         if os.path.exists(run_dir_single):
             if overwrite:
                 rmtree(run_dir_single)

--- a/profit/pre.py
+++ b/profit/pre.py
@@ -32,7 +32,7 @@ def fill_run_dir(eval_points, template_dir='template/', run_dir='run/',
     write_input(eval_points)
 
     for krun in kruns:
-        run_dir_single = os.path.join(run_dir, str(krun).zfill(3))
+        run_dir_single = os.path.join(run_dir, str(krun).zfill(3)) #.zfill(3) is an option that forces krun to have 3 digits
         if os.path.exists(run_dir_single):
             if overwrite:
                 rmtree(run_dir_single)


### PR DESCRIPTION
We have to add .zfill(3) to each of the 3 scripts in order to have a generated folder name with 3 digits