### PR TITLE
Fix numpy version mismatch when compiling fortran

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ pip install -e . --user
 ```
 
 ### Options
-* Disable compilation of the fortran modules
+* Enable compilation of the fortran modules
 
-        pip install . --global-option "--no-fortran"
+        pip install . --global-option "--fortran"
 
 * Install requirements for building the documentation using `sphinx`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Specifying the build system - PEP 517
 
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,9 @@ if __name__ == "__main__":
     # explicitly allow installation in user site in development mode
     site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
-    # forgo compiling fortran while building the docs for readthedocs
-    if os.environ.get('READTHEDOCS') == 'True':
-        setup()
-    elif "--no-fortran" in sys.argv[1:]:
-        sys.argv.remove("--no-fortran") # need to remove argument before setup() is called
-        setup()
-    else:
+    if "--fortran" in sys.argv[1:]:
+        sys.argv.remove("--fortran")  # need to remove argument before setup() is called
         setup(ext_modules=[ext_gpfunc, ext_kernels])
+    else:
+        setup()
 


### PR DESCRIPTION
Configure build to use the oldest supported fortran
 - seems to cause an error with python3.7, works with 3.8
Set the default to not compile fortran
 - add `--fortran` as build flag
Partially fixes #75