### PR TITLE
Fix numpy version mismatch when compiling fortran + running tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,12 +26,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install setuptools wheel
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install package
       run: |
-        python -m pip install -e .
-        python setup.py build --fortran
+        USE_FORTRAN=1 python -m pip install -e .
  #   - name: Lint with flake8
  #     run: |
  #       # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     - name: Install package
       run: |
         python -m pip install -e .
-        python setup.py build
+        python setup.py build --fortran
  #   - name: Lint with flake8
  #     run: |
  #       # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install -e . --user
 ### Options
 * Enable compilation of the fortran modules
 
-        pip install . --global-option "--fortran"
+        USE_FORTRAN=1 pip install .
 
 * Install requirements for building the documentation using `sphinx`
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ pip install -e . --user
 ```
 
 ### Options
-* Disable compilation of the fortran modules
+* Enable compilation of the fortran modules
 
-        pip install . --global-option "--no-fortran"
+        pip install . --global-option "--fortran"
 
 * Install requirements for building the documentation using `sphinx`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 # Specifying the build system - PEP 517
 
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy"]
+requires = [
+    "setuptools", "wheel",
+    "numpy==1.16.0; python_version<='3.7' and platform_machine!='aarch64'",
+    "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'",
+    "numpy==1.19.3; python_version>='3.9' and platform_machine!='aarch64'",
+    "numpy==1.19.3; platform_machine=='aarch64'"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Specifying the build system - PEP 517
 
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@ license = MIT
 
 [options]
 python_requires = >= 3.7
-install_requires = 
-    numpy
+install_requires =
+    numpy>=1.16.0
     scipy
     matplotlib
     sympy
@@ -28,7 +28,7 @@ install_requires =
     h5py
     dash
     tqdm
-setup_requires = 
+setup_requires =
     pytest-runner
 tests_require = pytest
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,9 @@ if __name__ == "__main__":
     # explicitly allow installation in user site in development mode
     site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
-    # forgo compiling fortran while building the docs for readthedocs
-    if os.environ.get('READTHEDOCS') == 'True':
-        setup()
-    elif "--no-fortran" in sys.argv[1:]:
-        sys.argv.remove("--no-fortran") # need to remove argument before setup() is called
-        setup()
-    else:
+    if "--fortran" in sys.argv[1:]:
+        sys.argv.remove("--fortran")  # need to remove argument before setup() is called
         setup(ext_modules=[ext_gpfunc, ext_kernels])
+    else:
+        setup()
 

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from numpy.distutils.core import Extension, setup
 
 ext_kwargs = {
     'libraries': ['gomp'],
-    'extra_f90_compile_args': ['-Wall', '-march=native', '-O2', '-fopenmp', 
-                               '-g', '-fbacktrace']} 
+    'extra_f90_compile_args': ['-Wall', '-march=native', '-O2', '-fopenmp',
+                               '-g', '-fbacktrace']}
 
 ext_gpfunc = Extension(
     name='profit.sur.backend.gpfunc',
@@ -27,9 +27,8 @@ if __name__ == "__main__":
     # explicitly allow installation in user site in development mode
     site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
-    if "--fortran" in sys.argv[1:]:
-        sys.argv.remove("--fortran")  # need to remove argument before setup() is called
+    use_fortran = os.environ.get("USE_FORTRAN", None)
+    if use_fortran:
         setup(ext_modules=[ext_gpfunc, ext_kernels])
     else:
         setup()
-


### PR DESCRIPTION
 This is an extension of #83 where the build is done explicitly and tests are now also run for Python 3.7 again (lowest supported version, since it is in Debian stable). Numpy version is now pinned to >=1.16.0 to avoid further troubles ahead. Fixes #83