### PR TITLE
Polishing Slurm

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -119,12 +119,13 @@ The following gives an overview of all possible parameters
         .. code-block:: yaml
 
             class: slurm
-            parallel: 1         # maximum number of simultaneous runs (for spawn array)
+            parallel: null      # maximum number of simultaneous runs (for spawn array)
             sleep: 0            # number of seconds to sleep while (internally) polling
             poll: 60            # number of seconds between external polls (to catch failed runs), use with care!
             path: slurm.bash    # the path to the generated batch script (relative to the base directory)
             custom: false       # whether a custom batch script is already provided at 'path'
-            job_name: profit    # the name of the submitted jobs
+            prefix: srun        # prefix for the command
+            job-name: profit    # the name of the submitted jobs
             OpenMP: false       # whether to set OMP_NUM_THREADS and OMP_PLACES
             cpus: 1             # number of cpus (including hardware threads) to use (may specify 'all')
 
@@ -148,11 +149,13 @@ The following gives an overview of all possible parameters
         .. code-block:: yaml
 
             class: zeromq
-            bind: tcp://*:9000              # address the runner binds to
-            connect: tcp://localhost:9000   # address the workers connect to
-            timeout: 2500                   # zeromq polling timeout, in ms
-            retries: 3                      # number of zeromq connection retries
-            retry-sleep: 1                  # sleep between retries, in s
+            transport: tcp      # transport system used by zeromq
+            port: 9000          # port for the interface
+            bind: null          # override bind address used by zeromq
+            connect: null       # override connect address used by zeromq
+            timeout: 2500       # zeromq polling timeout, in ms
+            retries: 3          # number of zeromq connection retries
+            retry-sleep: 1      # sleep between retries, in s
 
     .. confval:: pre
 

--- a/profit/config.py
+++ b/profit/config.py
@@ -2,6 +2,7 @@ from os import path, getcwd
 from re import match, split
 import yaml
 from collections import OrderedDict
+from typing import Mapping
 
 from profit.run import Runner
 from profit.sur import Surrogate
@@ -200,6 +201,8 @@ class Config(OrderedDict):
             elif isinstance(v, (int, float)):
                 self['variables'][k] = {'kind': 'constant', 'range': variable_kinds.constant(v, size=self['ntrain'])}
                 self['variables'][k]['dtype'] = str(self['variables'][k]['range'].dtype)
+            elif isinstance(v, Mapping) and 'kind' in v:  # assume config dictionary is valid
+                self['variables'][k] = v
             else:
                 raise TypeError(f'cannot interpret variable {k} with value {v}')
 

--- a/profit/run/slurm.py
+++ b/profit/run/slurm.py
@@ -142,10 +142,11 @@ class SlurmRunner(Runner):
         """
         defaults = dict(parallel=None, sleep=0, poll=60,
                         path='slurm.bash', custom=False, prefix='srun',
-                        OpenMP=False, cpus=1)
-        defaults.update({'job-name': 'profit'})
+                        OpenMP=False, cpus=1,
+                        account=None, parition=None, qos=None, constraint=None)
+        defaults.update({'job-name': 'profit', 'mem-per-cpu': None})
 
-        for key, value in defaults:
+        for key, value in defaults.items():
             if key not in config:
                 config[key] = value
 
@@ -162,9 +163,12 @@ class SlurmRunner(Runner):
 # automatically generated SLURM batch script for running simulations with proFit
 # see https://github.com/redmod-team/profit
 
-#SBATCH --job-name={self.config['job-name']}
+"""
+        for key in ['job-name', 'account', 'partition', 'qos', 'constraint', 'mem-per-cpu']:
+            if self.config[key] is not None:
+                text += f"\n#SBATCH --{key}={self.config[key]}"
 
-#SBATCH --ntasks=1"""
+        text += "\n#SBATCH --ntasks=1"
         if self.config['cpus'] == 'all':
             text += """
 #SBATCH --nodes=1

--- a/profit/run/slurm.py
+++ b/profit/run/slurm.py
@@ -89,7 +89,7 @@ class SlurmRunner(Runner):
                 self.del_run(run_id)
         # poll the slurm scheduler to check for crashed runs
         if poll:
-            acct = subprocess.run(['sacct', f'--name={self.config["job_name"]}', '--brief', '--parsable2'],
+            acct = subprocess.run(['sacct', f'--name={self.config["job-name"]}', '--brief', '--parsable2'],
                                   capture_output=True, text=True, check=True)
             lookup = {job: run for run, job in self.runs.items()}
             for line in acct.stdout.split('\n'):
@@ -116,7 +116,7 @@ class SlurmRunner(Runner):
     def clean(self):
         """remove generated scripts and any slurm-stdout-files which match ``slurm-*.out``"""
         super().clean()
-        if not self.config['custom']:
+        if not self.config['custom'] and os.path.exists(self.config['path']):
             os.remove(self.config['path'])
         for direntry in os.scandir(self.base_config['run_dir']):
             if direntry.is_file() and direntry.name.startswith('slurm-') and direntry.name.endswith('.out'):

--- a/profit/run/slurm.py
+++ b/profit/run/slurm.py
@@ -143,7 +143,7 @@ class SlurmRunner(Runner):
         defaults = dict(parallel=None, sleep=0, poll=60,
                         path='slurm.bash', custom=False, prefix='srun',
                         OpenMP=False, cpus=1,
-                        account=None, parition=None, qos=None, constraint=None)
+                        account=None, partition=None, qos=None, constraint=None)
         defaults.update({'job-name': 'profit', 'mem-per-cpu': None})
 
         for key, value in defaults.items():

--- a/profit/util/variable_kinds.py
+++ b/profit/util/variable_kinds.py
@@ -32,3 +32,7 @@ def independent(start=0, end=1, step=1, size=None):
 
 def activelearning(size=None):
     return check_ndim(np.full(size, np.nan))
+
+
+def constant(value=0, size=None):
+    return check_ndim(np.full(size, value))


### PR DESCRIPTION
* make setting an input variable or configuration variable easier
  * [x] add a `Constant` `variable_kind`
  * [x] shorthand for `Constant` 
* **VSC:** allow configuration of extra Slurm parameters
  * [x] `account`, `partition`, `qos`
  * [x] `mem-per-cpu`, `constraint`
  * [ ] testing
* **VSC:** fix zeromq interface
  * [x] hand over runner `hostname` with environment variable, using `SLURM_SUBMIT_HOST`
  runs should then be started with `srun profit run`, preferably with a previously acquired allocation 
  (e.g. `salloc --mem=1GB -n 1 -c 1 bash`)
* Reliability
  * [ ] handle non-zero exit code of `sbatch`
  * [ ] align input and output file (remove input parameters for runs which failed)
    * **or:** reschedule failed runs
* Fixes
  * [x] reading config from `.py` file

Documentation will be done in a separate PR.