### PR TITLE
prepare v0.4 for packaging

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,37 @@
+# Publish a GitHub Release to PyPI automatically
+# customized from:
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish Releases to PyPI
+
+on:
+  release:
+    type: [published]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,7 +5,7 @@ name: Publish Releases to PyPI
 
 on:
   release:
-    type: [published]
+    type: [released]
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,4 +34,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,24 +21,32 @@ If you encounter any bugs, problems or specific missing features, please open an
 context information. 
 
 ## Organization and planning
-Two [project boards](https://github.com/redmod-team/profit/projects) are used with the main repository.
+Three types of [project boards](https://github.com/redmod-team/profit/projects) are used with the main repository.
 
-**Vision** for strategy, use cases and user stories
+**Vision** for strategy, use cases and user stories.
 
-**Tasks** for priorization and tracking issues and pull requests
+**Tasks** for prioritization and tracking issues and pull requests. Each version has it's own board.
+
+**Testing** for gathering observations in preparation of a new release. 
 
 ## git
 proFit uses *git* as VCS. The upstream repository is located at https://github.com/redmod-team/profit. Currently the
 upstream repository contains only one branch.
 
-Contributors should fork this repository, push changes to their fork and make pull requests to merge them back into 
-upstream. Before merging the pull request should be reviewed by a maintainer and any changes can be discussed. For
+Contributors should fork this repository, push changes to their fork and make *pull requests* to merge them back into 
+upstream. Before merging, the pull request should be reviewed by a maintainer and any changes can be discussed. For
 larger projects use *draft pull requests* to show others your current progress. They can also be tracked in the relevant
 *Projects*, added to release schedules and features can be discussed easily.
+
+To try out new features which have not been merged yet, you can just add any fork to your repository with 
+`git remote add <name> <url>` and merge it locally. Do not push this merge to your fork.
 
 The default method to resolve conflicts is to rebase the personal fork onto `upstream` before merging.
 
 Please also use *interactive rebase* to squash intermediate commits if you use many small commits.
+
+### Jupyter Notebooks
+TODO
 
 ## Documentation
 The project documentation is maintained in the `doc` directory of the repository. proFit uses *Sphinx* and *rst* markup.
@@ -56,12 +64,31 @@ Running `make html` inside the `doc` folder creates output HTML file in `_build`
 
 ## Packaging
 proFit is still in development. There is currently no stable release. It is planned to manage releases on *github* and 
-publish them on *PyPi*
+publish them on *PyPi*.
 
-proFit uses the new build system, as specified by PEP 517. The build system is defined in `pyproject.toml`. Package 
-metadata and requirements are specified in `setup.cfg`. Unfortunately building the *fortran* backend requires a 
-`setup.py` script in addition.
+proFit uses the new build system, as specified by PEP 517. The build system is defined in `pyproject.toml` and uses the 
+default `setuptools` and `wheels`. Package 
+metadata and requirements are specified in `setup.cfg`. Building the *fortran* backend requires a 
+`setup.py` and `numpy` installed during the build process.
+
+To upload a new version to *PyPi*, follow this [guide](https://packaging.python.org/tutorials/packaging-projects/). In 
+the process you will require the packages `build` and `twine`.
+
+When a new version is tagged, update the corresponding number in the toplevel `__init__.py`. The package metadata reads
+this variable.
 
 ## Testing
-proFit uses *pytest* for automatic testing. A pull request on github triggers automatic testing with the supported
+proFit uses `pytest` for automatic testing. A pull request on github triggers automatic testing with the supported
 python versions. 
+
+## Coding
+### Dependencies
+Some calls to proFit should be completed very fast, but our many dependencies can slow down the startup time 
+significantly. Therefore be careful where you import big packages like `GPy` or `sklearn`. Consider using import 
+statements at the start of the function.
+
+Investigating the tree of imported packages can be done graphically with `tuna`:
+```
+python -X importtime -c "import profit" 2> profit_import.log
+tuna profit_import.log
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,18 +67,15 @@ proFit is still in development. There is currently no stable release. It is plan
 publish them on *PyPi*.
 
 proFit uses the new build system, as specified by PEP 517. The build system is defined in `pyproject.toml` and uses the 
-default `setuptools` and `wheels`. Package 
-metadata and requirements are specified in `setup.cfg`. Building the *fortran* backend requires a 
-`setup.py` and `numpy` installed during the build process.
+default `setuptools` and `wheels`.
+Package metadata and requirements are specified in `setup.cfg`. Building the *fortran* backend requires a 
+`setup.py` file and `numpy` installed during the build process.
 
-To upload a new version to *PyPi*, follow this [guide](https://packaging.python.org/tutorials/packaging-projects/). In 
-the process you will require the packages `build` and `twine`.
-
-When a new version is tagged, update the corresponding number in the toplevel `__init__.py`. The package metadata reads
-this variable.
+Upon publishing a new release in *GitHub*, a workflow should automatically upload the package to *PyPI*.
+To create a release manually follow this [guide](https://packaging.python.org/tutorials/packaging-projects/)
 
 ## Testing
-proFit uses `pytest` for automatic testing. A pull request on github triggers automatic testing with the supported
+proFit uses `pytest` for automatic testing. A pull request on *GitHub* triggers automatic testing with the supported
 python versions. 
 
 ## Coding

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/168945305.svg)](https://zenodo.org/badge/latestdoi/168945305)
 [![Documentation Status](https://readthedocs.org/projects/profit/badge/?version=latest)](https://profit.readthedocs.io/en/latest/?badge=latest)
 
-<img src="logo.png" width="208.5px">
+<img src="https://raw.githubusercontent.com/redmod-team/profit/master/logo.png" width="208.5px">
 
 ## Probabilistic Response Model Fitting with Interactive Tools
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![DOI](https://zenodo.org/badge/168945305.svg)](https://zenodo.org/badge/latestdoi/168945305)
+
 [![Documentation Status](https://readthedocs.org/projects/profit/badge/?version=latest)](https://profit.readthedocs.io/en/latest/?badge=latest)
+[![Python package](https://github.com/redmod-team/profit/actions/workflows/python-package.yml/badge.svg?)](https://github.com/redmod-team/profit/actions/workflows/python-package.yml)
+[![Publish Releases to PyPI](https://github.com/redmod-team/profit/actions/workflows/publish-to-pypi.yml/badge.svg)](https://github.com/redmod-team/profit/actions/workflows/publish-to-pypi.yml)
 
 <img src="https://raw.githubusercontent.com/redmod-team/profit/master/logo.png" width="208.5px">
 

--- a/profit/__init__.py
+++ b/profit/__init__.py
@@ -15,3 +15,4 @@ from . import config
 
 from . import util
 
+__version__ = '0.4.dev0'

--- a/profit/__init__.py
+++ b/profit/__init__.py
@@ -15,4 +15,17 @@ from . import config
 
 from . import util
 
-__version__ = '0.4.dev0'
+# Retrieving package version at runtime
+# https://pypi.org/project/setuptools-scm/
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:  # required for python3.7
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("profit")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
+del version, PackageNotFoundError  # clean up namespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,11 @@
 
 [build-system]
 requires = [
-    "setuptools", "wheel",
+    "setuptools>=42",
+    "wheel",
     "numpy==1.16.0; python_version<='3.7' and platform_machine!='aarch64'",
     "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'",
     "numpy==1.19.3; python_version>='3.9' and platform_machine!='aarch64'",
-    "numpy==1.19.3; platform_machine=='aarch64'"]
+    "numpy==1.19.3; platform_machine=='aarch64'",
+]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,10 @@ requires = [
     "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'",
     "numpy==1.19.3; python_version>='3.9' and platform_machine!='aarch64'",
     "numpy==1.19.3; platform_machine=='aarch64'",
+    "setuptools_scm[toml]>=3.4"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# infers current version from git tag + commit
+# includes all file tracked by git in the source distribution

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,15 +3,28 @@
 
 [metadata]
 name = profit
-version = 0.4.alpha.dev
-#TODO version = attr: profit.__version__
+version = attr: profit.__version__
 author = Christopher Albert
 author_email = albert@alumni.tugraz.at
-url = https://github.com/redmod-team/profit
-description = Probabilistic response surface fitting
+description = Probabilistic response model fitting with interactive tools
 long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/redmod-team/profit
+project_urls = 
+    Issue Tracker = https://github.com/redmod-team/profit/issues
+    Documentation = https://profit.readthedocs.io/en/latest
 keywords = PCE, UQ
-license = MIT
+classifiers = 
+    Development Status :: 3 - Alpha
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: POSIX :: Linux
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Visualization
 
 [options]
 python_requires = >= 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@
 
 [metadata]
 name = profit
-version = attr: profit.__version__
 author = Christopher Albert
 author_email = albert@alumni.tugraz.at
 description = Probabilistic response model fitting with interactive tools
@@ -14,6 +13,7 @@ project_urls =
     Issue Tracker = https://github.com/redmod-team/profit/issues
     Documentation = https://profit.readthedocs.io/en/latest
 keywords = PCE, UQ
+license = MIT
 classifiers = 
     Development Status :: 3 - Alpha
     Programming Language :: Python :: 3
@@ -42,8 +42,7 @@ install_requires =
     dash>=1.20.0
     tqdm
     zmq
-setup_requires =
-    pytest-runner
+    importlib_metadata; python_version<'3.8'
 tests_require = pytest
 packages = find:
 include_package_data = True


### PR DESCRIPTION
* [x] update project metadata
* [x] single-source version as `profit.__version__` (within the toplevel `__init__.py`)
  * [x] using `setuptools_scm` the version is constructed from the *git* tag + commit
  * should uniquely identify local versions (how this works with rebases remains to be seen)
* [x] include `logo.png` in the `README` on PyPI (image link now points to github)
* [x] test with `test.pypi.org`
* [x] set up automatic publishing on PyPI using a GitHub Action when a new Release is published from GitHub
  * [x] tested

## Todo after merge:
* @krystophny should add a new PyPI API token as a secret to this repository. Limit the scope on PyPI to profit only. [(reference)](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)
* delete the last line in `.github/workflows/publish-to-pypi.yml` (with `repository_url`)
* create a new release with the github ui (e.g. `v0.4-rc`)
* ideally the action should only trigger when the Release is released, but
  * it might not trigger if we specify a pre-release (which might actually be intended as we might not want pre releases on PyPI)
  * it might trigger more often (happened during testing)
  * reference for [triggers](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release)
* test installation using pip (somehow didn't work with test-pypi)
* update installation instructions