### PR TITLE
Resizing Runner-Interface

### DIFF
--- a/profit/run/default.py
+++ b/profit/run/default.py
@@ -136,7 +136,11 @@ class MemmapRunnerInterface(RunnerInterface):
         Any Workers which have this file mapped will run into severe problems.
         Possible future workarounds: multiple files or multiple headers in one file.
         """
-        self.logger.warn('resizing MemmapRnnerInterface is dangerous')
+        if size <= self.size:
+            self.logger.warning('shrinking RunnerInterface is not supported')
+            return
+        
+        self.logger.warning('resizing MemmapRunnerInterface is dangerous')
         self.clean()
         init_data = np.zeros(size, dtype=self.input_vars + self.internal_vars + self.output_vars)
         np.save(self.config['path'], init_data)

--- a/profit/run/runner.py
+++ b/profit/run/runner.py
@@ -36,7 +36,7 @@ class RunnerInterface:
     
     def resize(self, size):
         if size <= self.size:
-            self.logger.warn('shrinking RunnerInterface is not supported')
+            self.logger.warning('shrinking RunnerInterface is not supported')
             return
         self.input.resize(size)  # filled with 0 by default
         self.output.resize(size)

--- a/tests/run/test_components.py
+++ b/tests/run/test_components.py
@@ -33,28 +33,6 @@ def assert_wif(wif):
     assert wif.input['v'] == VALUE_V
 
 
-def test_resize_memmap():
-    from profit.run.default import MemmapInterface, MemmapRunnerInterface
-    from profit.config import MemmapInterfaceConfig
-    import os
-
-    BASE_CONFIG = BaseConfig.from_file(CONFIG_FILE)
-    MAX_IDS = BASE_CONFIG['ntrain']
-    config = MemmapInterfaceConfig(**{'class': 'memmap'})
-    config.process_entries(BASE_CONFIG)
-    
-    try:
-        rif = MemmapRunnerInterface(config, MAX_IDS, BASE_CONFIG['input'], BASE_CONFIG['output'])
-        assert rif.size == MAX_IDS
-        rif.resize(MAX_IDS - 5)  # shrinking (not supported)
-        assert rif.size == MAX_IDS
-        rif.resize(MAX_IDS + 5)  # expanding
-        assert rif.size == MAX_IDS + 5
-    finally:
-        if config.get('path') and os.path.exists(config['path']):
-            os.remove(config['path'])
-
-
 def test_memmap():
     from profit.run.default import MemmapInterface, MemmapRunnerInterface
     from profit.config import MemmapInterfaceConfig
@@ -121,6 +99,49 @@ def test_zeromq():
     wt.start()
     wt.join()
     rt.join()
+
+
+def test_resize_memmap():
+    from profit.run.default import MemmapInterface, MemmapRunnerInterface
+    from profit.config import MemmapInterfaceConfig
+    import os
+
+    BASE_CONFIG = BaseConfig.from_file(CONFIG_FILE)
+    MAX_IDS = BASE_CONFIG['ntrain']
+    config = MemmapInterfaceConfig(**{'class': 'memmap'})
+    config.process_entries(BASE_CONFIG)
+    
+    try:
+        rif = MemmapRunnerInterface(config, MAX_IDS, BASE_CONFIG['input'], BASE_CONFIG['output'])
+        assert rif.size == MAX_IDS
+        rif.resize(MAX_IDS - 5)  # shrinking (not supported)
+        assert rif.size == MAX_IDS
+        rif.resize(MAX_IDS + 5)  # expanding
+        assert rif.size == MAX_IDS + 5
+    finally:
+        if config.get('path') and os.path.exists(config['path']):
+            os.remove(config['path'])
+
+
+def test_resize_zeromq():
+    from profit.run.zeromq import ZeroMQInterface, ZeroMQRunnerInterface
+    from profit.config import ZeroMQInterfaceConfig
+    import os
+
+    BASE_CONFIG = BaseConfig.from_file(CONFIG_FILE)
+    MAX_IDS = BASE_CONFIG['ntrain']
+    config = ZeroMQInterfaceConfig(**{'class': 'zeromq'})
+    config.process_entries(BASE_CONFIG)
+    
+    try:
+        rif = ZeroMQRunnerInterface(config, MAX_IDS, BASE_CONFIG['input'], BASE_CONFIG['output'])
+        assert rif.size == MAX_IDS
+        rif.resize(MAX_IDS - 5)  # shrinking (not supported)
+        assert rif.size == MAX_IDS
+        rif.resize(MAX_IDS + 5)  # expanding
+        assert rif.size == MAX_IDS + 5
+    finally:
+        rif.clean()
 
 
 def test_numpytxt():


### PR DESCRIPTION
As discussed on 2021-10-15, it’s sometimes necessary to resize the Interface as more runs are required.

## Added:
- RunnerInterface.resize()
- RunnerInterface.size
- two unit tests for resizing `zeromq` and `memmap`

Added automatic resizing for:
- Runner.fill()
- Runner.spawn_run()

## Problems:
 - Resizing MemmapInterface is implemented but errors are expected if a Worker already has the old Memmap loaded.
 - The Runner automatically resizes the interface but does not check whether a Worker is already running.
 - The tests only check the manual resizing, automatic resizing is not tested and no code actually uses resizing yet.

## To Do:
 - [x] Testing