### PR TITLE
prepare `v0.5`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+Christopher Albert <albert@alumni.tugraz.at> <chr.albert@gmail.com>
+Christopher Albert <albert@alumni.tugraz.at> <krystophny@users.noreply.github.com>
+Maximilian Kendler <mkendler@student.tugraz.at> Kendler, Maximilian
+Maximilian Kendler <mkendler@student.tugraz.at> <77534506+mkendler@users.noreply.github.com>
+Michael Hadwiger <m.hadwiger@student.tugraz.at> <78954154+michad1111@users.noreply.github.com>
+Francesco Kramp <francesco.kramp@student.tugraz.at> Squadula
+Manal Khallaayoune <66592517+manal44@users.noreply.github.com> manal44
+Manal Khallaayoune <66592517+manal44@users.noreply.github.com> <manalkh567@gmail.com>
+Katharina Rath <katharinarath@gmx.at> KathiRath

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,53 @@
+{
+    "description": "<p>Collection of tools for studying parametric dependencies of black-box simulation codes or experiments and construction of reduced order response models over input parameter space.</p>", 
+    "license": "MIT", 
+    "title": "proFit v0.4: Probabilistic Response Model Fitting with Interactive Tools", 
+    "version": "v0.4", 
+    "upload_type": "software", 
+    "publication_date": "2021-05-28", 
+    "creators": [
+        {
+            "orcid": "0000-0003-4773-416X", 
+            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
+            "name": "Christopher Albert"
+        }, 
+        {
+            "affiliation": "Technische Universit\u00e4t Graz", 
+            "name": "Robert Babin"
+        }, 
+        {
+            "affiliation": "Technische Universit\u00e4t Graz", 
+            "name": "Michael Hadwiger"
+        }, 
+        {
+            "affiliation": "Technische Universit\u00e4t Graz", 
+            "name": "Maximilian Kendler"
+        }, 
+        {
+            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
+            "name": "Manal Khallaayoune"
+        }, 
+        {
+            "orcid": "0000-0002-4962-5656", 
+            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
+            "name": "Katharina Rath"
+        }, 
+        {
+            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
+            "name": "Baptiste Rubino-Moyner"
+        }
+    ], 
+    "access_right": "open", 
+    "related_identifiers": [
+        {
+            "scheme": "url", 
+            "identifier": "https://github.com/redmod-team/profit/tree/v0.4", 
+            "relation": "isSupplementTo"
+        }, 
+        {
+            "scheme": "doi", 
+            "identifier": "10.5281/zenodo.3580488", 
+            "relation": "isVersionOf"
+        }
+    ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
-   "description":"Collection of tools for studying parametric dependencies of black-box simulation codes or experiments and construction of reduced order response models over input parameter space.",
-   "license":"MIT",
+   "description":"<p>proFit is a collection of tools for studying parametric dependencies of black-box simulation codes or experiments and construction of reduced order response models over input parameter space.</p><p>proFit can be fed with a number of data points consisting of different input parameter combinations and the resulting output of the simulation under investigation. It then fits a response-surface through the point cloud using Gaussian process regression (GPR) models. This probabilistic response model allows to predict (interpolate) the output at yet unexplored parameter combinations including uncertainty estimates. It can also tell you where to put more training points to gain maximum new information (experimental design) and automatically generate and start new simulation runs locally or on a cluster. Results can be explored and checked visually in a web frontend.</p><p>Telling proFit how to interact with your existing simulations is easy and requires no changes in your existing code. Current functionality covers starting simulations locally or on a cluster via <a href=\"https://slurm.schedmd.com\">Slurm</a>, subsequent surrogate modelling using <a href=\"https://github.com/SheffieldML/GPy\">GPy</a>, <a href=\"https://github.com/scikit-learn/scikit-learn\">scikit-learn</a>, as well as an active learning algorithm to iteratively sample at interesting points and a Markov-Chain-Monte-Carlo (MCMC) algorithm. The web frontend to interactively explore the point cloud and surrogate is based on <a href=\"https://github.com/plotly/dash\">plotly/dash</a>.</p><p>Features include: <ul><li>Compute evaluation points (e.g. from a random distribution) to run simulation</li><li>Template replacement and automatic generation of run directories</li><li>Starting parallel runs locally or on the cluster (SLURM)</li><li>Collection of result output and postprocessing</li><li>Response-model fitting using GPR</li><li>Active learning to reduce number of samples needed</li><li>MCMC to find a posterior parameter distribution (similar to active learning)</li><li>Graphical user interface to explore the results</li></ul></p>",
+  "license":"MIT",
    "title":"proFit: Probabilistic Response Model Fitting with Interactive Tools",
    "creators":[
       {
@@ -18,15 +18,19 @@
       },
       {
          "affiliation":"Technische Universit\u00e4t Graz",
-         "name":"Francesco Kramp"
+         "name":"Michael Hadwiger"
       },
       {
-         "affiliation":"Technische Universit\u00e4t Graz",
-         "name":"Michael Hadwiger"
+         "affiliation":"Helmholtz-Zentrum Geesthacht",
+         "name":"Richard Hofmeister"
       },
       {
          "affiliation":"Max-Planck-Institut f\u00fcr Plasmaphysik",
          "name":"Manal Khallaayoune"
+      },
+      {
+         "affiliation":"Technische Universit\u00e4t Graz",
+         "name":"Francesco Kramp"
       },
       {
          "orcid":"0000-0002-4962-5656",
@@ -40,8 +44,10 @@
    ],
    "keywords":[
       "Parameter Study",
-      "GP",
+      "Gaussian Process",
+      "Regression",
       "HPC",
-      "Active Learning",
-   ],
+      "Active Learning"
+   ]
 }
+

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,53 +1,47 @@
 {
-    "description": "<p>Collection of tools for studying parametric dependencies of black-box simulation codes or experiments and construction of reduced order response models over input parameter space.</p>", 
-    "license": "MIT", 
-    "title": "proFit v0.4: Probabilistic Response Model Fitting with Interactive Tools", 
-    "version": "v0.4", 
-    "upload_type": "software", 
-    "publication_date": "2021-05-28", 
-    "creators": [
-        {
-            "orcid": "0000-0003-4773-416X", 
-            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
-            "name": "Christopher Albert"
-        }, 
-        {
-            "affiliation": "Technische Universit\u00e4t Graz", 
-            "name": "Robert Babin"
-        }, 
-        {
-            "affiliation": "Technische Universit\u00e4t Graz", 
-            "name": "Michael Hadwiger"
-        }, 
-        {
-            "affiliation": "Technische Universit\u00e4t Graz", 
-            "name": "Maximilian Kendler"
-        }, 
-        {
-            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
-            "name": "Manal Khallaayoune"
-        }, 
-        {
-            "orcid": "0000-0002-4962-5656", 
-            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
-            "name": "Katharina Rath"
-        }, 
-        {
-            "affiliation": "Max-Planck-Institut f\u00fcr Plasmaphysik", 
-            "name": "Baptiste Rubino-Moyner"
-        }
-    ], 
-    "access_right": "open", 
-    "related_identifiers": [
-        {
-            "scheme": "url", 
-            "identifier": "https://github.com/redmod-team/profit/tree/v0.4", 
-            "relation": "isSupplementTo"
-        }, 
-        {
-            "scheme": "doi", 
-            "identifier": "10.5281/zenodo.3580488", 
-            "relation": "isVersionOf"
-        }
-    ]
+   "description":"Collection of tools for studying parametric dependencies of black-box simulation codes or experiments and construction of reduced order response models over input parameter space.",
+   "license":"MIT",
+   "title":"proFit: Probabilistic Response Model Fitting with Interactive Tools",
+   "creators":[
+      {
+         "orcid":"0000-0003-4773-416X",
+         "affiliation":"Technische Universit\u00e4t Graz",
+         "name":"Christopher Albert"
+      },
+      {
+         "affiliation":"Technische Universit\u00e4t Graz",
+         "name":"Maximilian Kendler"
+      },
+      {
+         "affiliation":"Technische Universit\u00e4t Graz",
+         "name":"Robert Babin"
+      },
+      {
+         "affiliation":"Technische Universit\u00e4t Graz",
+         "name":"Francesco Kramp"
+      },
+      {
+         "affiliation":"Technische Universit\u00e4t Graz",
+         "name":"Michael Hadwiger"
+      },
+      {
+         "affiliation":"Max-Planck-Institut f\u00fcr Plasmaphysik",
+         "name":"Manal Khallaayoune"
+      },
+      {
+         "orcid":"0000-0002-4962-5656",
+         "affiliation":"Max-Planck-Institut f\u00fcr Plasmaphysik",
+         "name":"Katharina Rath"
+      },
+      {
+         "affiliation":"Max-Planck-Institut f\u00fcr Plasmaphysik",
+         "name":"Baptiste Rubino-Moyner"
+      }
+   ],
+   "keywords":[
+      "Parameter Study",
+      "GP",
+      "HPC",
+      "Active Learning",
+   ],
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,8 @@ Package metadata and requirements are specified in `setup.cfg`. Building the *fo
 `setup.py` file and `numpy` installed during the build process.
 
 Upon publishing a new release in *GitHub*, a workflow should automatically upload the package to *PyPI*.
-To create a release manually follow this [guide](https://packaging.python.org/tutorials/packaging-projects/)
+To create a release manually follow this [guide](https://packaging.python.org/tutorials/packaging-projects/).
+The new version is automatically added to [zenodo](https://zenodo.org/record/4849489), make sure to update the metadata in `.zenodo.json`.
 
 ## Testing
 proFit uses `pytest` for automatic testing. A pull request on *GitHub* triggers automatic testing with the supported

--- a/doc/active_learning.rst
+++ b/doc/active_learning.rst
@@ -1,3 +1,5 @@
+.. _active_learning:
+
 Active Learning
 ===============
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1,3 +1,5 @@
+.. _config:
+
 Configuration
 =============
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,7 @@ Welcome to proFit's documentation!
    :caption: Contents:
 
    proFit <README>
+   start
    config
    cluster
    code_structure

--- a/doc/start.rst
+++ b/doc/start.rst
@@ -122,7 +122,7 @@ For a simulation which can be called from python directly, the recommended confi
 
 The type annotation is used to tell proFit which return value belongs to which return value if there are several. The configuration is then:
 
-.. code-block::
+.. code-block:: yaml
 
    run:
      worker: my_name
@@ -145,7 +145,7 @@ Everything should be ready to run now:
 
 * with :ref:`active_learning` enabled, the fit will already happen during the run step. Active Learning optimizes the paramters at which the simulation is run to gain as much value per simulation run as possible
 
-* finally the results can be explored interactively in a browser after starting a ``plotly/dash`` server using ``profit ui``
+* finally the results can be explored interactively in a browser after starting a ``plotly/dash`` server using ``profit ui`` (see :ref:`ui`)
 
 
 There is a wide variety of configuration options to customize the run system, the surrogate fitting and the active learning algorithm. Please have a look at the documentation on the :ref:`config` and don't hestitate to contact the developers if you encounter any bugs.

--- a/doc/start.rst
+++ b/doc/start.rst
@@ -1,0 +1,152 @@
+.. _start:
+
+Getting Started
+===============
+
+This guide aims to give a rough overview over a full proFit workflow. Further examples of the configuration can be found in ``examples/`` and in ``tests/integration_tests/``.
+
+.. figure:: pics/profit_workflow.png
+   :width: 600
+   :align: center
+
+   The typical profit workflow
+
+
+The Configuration File
+----------------------
+
+proFit is controlled almost entirely via a single configuration file which is usually called ``profit.yaml``. Other filenames are permitted and the respective path can be given as an argument to the profit commands. The configuration is typically written using the YAML file format.
+
+The configuration uses mostly a hierachical structure closely mirroring the structure of the different components. Different implementations of the same component are usually selected using the ``class`` attribute. A shorter notation uses the label of the component directly and uses default values for all it's parameters. The following two snippets therefore are the same:
+
+
+.. code-block:: yaml
+
+    run:
+      interface:
+        class: zeromq
+
+.. code-block:: yaml
+
+   run:
+     interface: zeromq
+
+
+There are also shorthand notations for Variables and Encoders.
+
+
+Set up simulation
+-----------------
+
+proFit currently distinguishes two types of simulations:
+
+* executables with input and output files
+    | the simulation reads its input parameters from a file, proFit prepares the file using a ``Preprocessor``
+    | the simulation writes its ouput values to a file, proFit read the file using a ``Postprocessor``
+
+* Python simulations which are called from a function
+    | the input parameters are the arguments of the function
+    | the output parameters are the return values
+    | proFit can wrap this function using a custom ``Worker``
+
+
+For both of these, the first step is usually ensuring that they are installed properly and run within a dedicated working directory. Find out which environment variables need to be set and link all relevant files. This directory will become the template directory which proFit will (usually) copy for each run of the simulation. Furthermore the simulation will just inherit the environment proFit was started in. A typical directory structure could look like this:
+
+.. code-block::
+
+   study/
+     profit.yaml
+     template/
+       simulation.x  ->  /path/to/simulation/executable.x
+       params.txt
+
+
+Variables
+---------
+
+The configuration file usually begins with ``ntrain:`` which set the desired number of data points. The next section is usually ``variables``. In it the different input parameters and output values are defined. For the parameters a suitable distribution from which the samples will be taken is selected. Additionally independent variables allow the output values to be vectors and constant values can also be set directly from proFit. More details can be found in :ref:`variables`.
+
+
+.. code-block:: yaml
+
+    ntrain: 100
+    variables:
+      u: Uniform(4.7, 5.3)
+      v: Uniform(0.55, 0.6)
+      n: 10000
+      f: Output
+ 
+
+Pre- & Postprocessor
+--------------------
+
+An executable simulation needs a ``Preprocessor`` and ``Postprocessor`` to prepare the input parameters and collect the results.
+
+The recommended Preprocessor is the :py:class:`profit.run.default.TemplatePreprocessor` which will fill placeholders in the template directory with the corresponding values.
+
+For the output values proFit currently supports JSON, HDF5 and CSV/TSV via three different Postprocessors. All the configuration options are given in :ref:`config`. A possible configuration is given below:
+
+.. code-block:: yaml
+
+    run:
+      command: ./simulation
+      pre:
+        class: template
+        path: ./path/to/template_directory
+        param_files:
+          - params.txt
+      post: json
+
+
+The contents of ``params.txt`` could look like this:
+
+.. code-block::
+
+    # just a plain csv
+    # u, v, n, m
+    {u}, {v}, {n}, 10
+
+
+Python Simulation
+-----------------
+
+For a simulation which can be called from python directly, the recommended configuration is different and uses :ref:`extensions` instead. A python function ``simulation`` which takes the input parameters as arguments and returns the output values can be registered with proFit in the following way:
+
+.. code-block:: python
+
+   from profit.run import Worker
+
+   @Worker.wrap("my_name")
+   def simulation(u, v) -> "f":
+       ...
+
+The type annotation is used to tell proFit which return value belongs to which return value if there are several. The configuration is then:
+
+.. code-block::
+
+   run:
+     worker: my_name
+
+
+Interface & Runner
+------------------
+
+The other two main components of the run system are the ``Interface`` and the ``Runner`` itself. These play a vital role if the simulation should be scheduled on a cluster, rather than run locally. For more information see :ref:`cluster`.
+
+
+Next steps
+----------
+
+Everything should be ready to run now:
+
+* calling ``profit run`` will start start ``ntrain`` simulations with different parameters and collect their results
+
+* calling ``profit fit`` will then use these results to fit a surrogate model which is configured in the ``fit`` section (see :ref:`surrogates`)
+
+* with :ref:`active_learning` enabled, the fit will already happen during the run step. Active Learning optimizes the paramters at which the simulation is run to gain as much value per simulation run as possible
+
+* finally the results can be explored interactively in a browser after starting a ``plotly/dash`` server using ``profit ui``
+
+
+There is a wide variety of configuration options to customize the run system, the surrogate fitting and the active learning algorithm. Please have a look at the documentation on the :ref:`config` and don't hestitate to contact the developers if you encounter any bugs.
+

--- a/profit/main.py
+++ b/profit/main.py
@@ -19,7 +19,14 @@ def main():
     from profit import __version__  # delayed to prevent cyclic import
 
     # Get parameters from shell input
-    parser = ArgumentParser(description=f"Probabilistic Response Model Fitting with Interactive Tools v{__version__}")
+    # display help by default: https://stackoverflow.com/questions/4042452/display-help-message-with-python-argparse-when-script-is-called-without-any-argu
+    class MyParser(ArgumentParser):
+        def error(self, message):
+            sys.stderr.write(f"error: {message}\n")
+            self.print_help(sys.stderr)
+            self.exit(2)
+
+    parser = MyParser(description=f"Probabilistic Response Model Fitting with Interactive Tools v{__version__}")
     subparsers = parser.add_subparsers(metavar="mode", dest="mode", required=True)
     subparsers.add_parser("run", help="start simulation runs")
     subparsers.add_parser("fit", help="fit data (e.g. with a Gaussian Process)")

--- a/profit/main.py
+++ b/profit/main.py
@@ -24,9 +24,10 @@ def main():
     subparsers.add_parser("run", help="start simulation runs")
     subparsers.add_parser("fit", help="fit data (e.g. with a Gaussian Process)")
     subparsers.add_parser("ui", help="interactively visualize results using dash")
+    subparsers.choices["ui"].add_argument("--debug", action="store_true", help="activate debug mode for the Dash app")
     subparsers.add_parser("clean", help="remove temporary files, run directories and logs")
-    subparsers.add_parser("version", help="show version information")
     subparsers.choices["clean"].add_argument("--all", action="store_true", help="remove input, output and model files")
+    subparsers.add_parser("version", help="show version information")
 
     parser.add_argument('base_dir',
                         metavar='base-dir',
@@ -156,7 +157,7 @@ def main():
     elif args.mode == 'ui':
         from profit.ui import init_app
         app = init_app(config)
-        app.run_server(debug=True)  # Start Dash server on localhost
+        app.run_server(debug=args.debug)  # Start Dash server on localhost
 
     elif args.mode == 'clean':
         from shutil import rmtree

--- a/profit/ui/app.py
+++ b/profit/ui/app.py
@@ -1,6 +1,6 @@
 import dash
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import dcc
+from dash import html
 import plotly.graph_objs as go
 from dash.dependencies import Input, Output, State, MATCH, ALL
 from math import log10
@@ -11,11 +11,13 @@ from matplotlib import cm as colormaps
 from matplotlib.colors import to_hex as color2hex
 
 def init_app(config):
+    from profit import __version__  # delayed to prevent cyclic import
     external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 
     app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
     server = app.server
     app.config.suppress_callback_exceptions = False
+    app.title = f"proFit UI v{__version__}"
 
     indata = FileHandler.load(config['files']['input']).flatten()
     outdata = FileHandler.load(config['files']['output']).flatten()

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/redmod-team/profit
 project_urls = 
     Issue Tracker = https://github.com/redmod-team/profit/issues
     Documentation = https://profit.readthedocs.io/en/latest
-keywords = PCE, UQ
+keywords = Parameter Study, GP, HPC, Active Learning
 license = MIT
 classifiers = 
     Development Status :: 3 - Alpha

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/redmod-team/profit
 project_urls = 
     Issue Tracker = https://github.com/redmod-team/profit/issues
     Documentation = https://profit.readthedocs.io/en/latest
-keywords = Parameter Study, GP, HPC, Active Learning
+keywords = Parameter Study, Gaussian Process, Regression, HPC, Active Learning
 license = MIT
 classifiers = 
     Development Status :: 3 - Alpha


### PR DESCRIPTION
* [x] add *Getting Started* page to documentation
  * explain the necessary steps to set up proFit with a simulation
  * reference further reading: variables, surrogates, cluster support, ...
* [x] add version information to UI
* [x] add `--debug` flag to UI to explicitly enable dash debug mode
* [x] fix import paths for dash
  * Chris: verified that it works for python 3.7
* [x] add & update zenodo metadata
  * [x] add the first three paragraphs of the README to zenodo, & the list of features
* [x] update keywords
* [x] default help message

<details><summary>preview of Zenodo description</summary>

![image](https://user-images.githubusercontent.com/18230626/168294075-78406041-ec5b-40f2-9a68-f53d85addfc2.png)
</details>

<details><summary>preview of Getting Started docs</summary>

![image](https://user-images.githubusercontent.com/18230626/168294968-419f5e7b-b27b-483a-b458-ef8d3e62e897.png)
![image](https://user-images.githubusercontent.com/18230626/168295024-96055dc6-f4ad-45c9-b804-93ad7766d2e5.png)
![image](https://user-images.githubusercontent.com/18230626/168295081-bc07a11a-35f3-4347-a00a-c07568091b17.png)
</details>

<details><summary>display help message on argument error</summary>

```
$ profit
error: the following arguments are required: mode
usage: profit [-h] mode ... [base-dir]

Probabilistic Response Model Fitting with Interactive Tools v0.5.dev58+gbd90fab

positional arguments:
  mode
    run       start simulation runs
    fit       fit data (e.g. with a Gaussian Process)
    ui        interactively visualize results using dash
    clean     remove temporary files, run directories and logs
    version   show version information
  base-dir    path to config file or directory containing profit.yaml (default: current working
              directory)

options:
  -h, --help  show this help message and exit
```
</details>