### PR TITLE
Harden local runner for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ not the Windows system.
 To configure the Python interpreter available in your Linux distribution in pycharm
 (tested with professional edition) follow this [guide](https://www.jetbrains.com/help/pycharm/using-wsl-as-a-remote-interpreter.html).
 
+Native Windows runs should avoid the Unix-oriented default of forked workers
+and memory-mapped ``interface.npy`` files. On Windows, proFit defaults to a
+subprocess runner with ZeroMQ communication:
+
+```yaml
+run:
+  runner:
+    class: local
+  interface:
+    class: zeromq
+  worker:
+    class: command
+```
+
+This avoids multiprocessing ``fork`` semantics, concurrent access to
+``interface.npy``, and template symlink creation. If a template contains
+symbolic links, Windows copies the linked files into each run directory.
+
 ### Installation from PyPI
 To install the latest stable version of proFit, use
 ```bash

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -145,10 +145,14 @@ Run config
     .. code-block:: yaml
 
         run:
-            runner: fork  # Local runner with its default parameters (see below).
-            interface: memmap  # Numpy memmap interface with its default parameters.
+            runner: fork  # POSIX default. On Windows the default is local.
+            interface: memmap  # POSIX default. On Windows the default is zeromq.
             worker: command  # Command worker with its default parameters
             debug: false  # override debug for Worker & Runner
+
+        On Windows, the default run configuration is ``runner: local`` and
+        ``interface: zeromq``. This avoids multiprocessing ``fork`` semantics,
+        concurrent access to ``interface.npy`` and template symlink creation.
 
     All runners
         .. code-block:: yaml

--- a/profit/defaults.py
+++ b/profit/defaults.py
@@ -1,6 +1,6 @@
 """Global default configuration values."""
 
-from os import path, getcwd
+from os import name as os_name, path, getcwd
 
 # Base Config
 base_dir = path.abspath(getcwd())
@@ -12,7 +12,13 @@ ntrain = 10
 variables = {}
 
 # Run Config
-run = {"runner": "fork", "interface": "memmap", "worker": "command"}
+def platform_run_defaults(platform=os_name):
+    if platform == "nt":
+        return {"runner": "local", "interface": "zeromq", "worker": "command"}
+    return {"runner": "fork", "interface": "memmap", "worker": "command"}
+
+
+run = platform_run_defaults()
 
 # Fit Config
 fit = {

--- a/profit/defaults.py
+++ b/profit/defaults.py
@@ -11,6 +11,7 @@ files = {"input": "input.txt", "output": "output.txt"}
 ntrain = 10
 variables = {}
 
+
 # Run Config
 def platform_run_defaults(platform=os_name):
     if platform == "nt":

--- a/profit/run/command.py
+++ b/profit/run/command.py
@@ -239,13 +239,22 @@ class TemplatePreprocessor(Preprocessor, label="template"):
     def copy_template(cls, template_dir, out_dir, dont_copy=None):
         from shutil import copytree, ignore_patterns
 
+        copy_symlinks = cls.copy_symlinks_supported()
         if dont_copy:
             copytree(
-                template_dir, out_dir, symlinks=True, ignore=ignore_patterns(*dont_copy)
+                template_dir,
+                out_dir,
+                symlinks=copy_symlinks,
+                ignore=ignore_patterns(*dont_copy),
             )
         else:
-            copytree(template_dir, out_dir, symlinks=True)
-        cls.convert_relative_symlinks(template_dir, out_dir)
+            copytree(template_dir, out_dir, symlinks=copy_symlinks)
+        if copy_symlinks:
+            cls.convert_relative_symlinks(template_dir, out_dir)
+
+    @staticmethod
+    def copy_symlinks_supported():
+        return os.name != "nt"
 
     @staticmethod
     def convert_relative_symlinks(template_dir, out_dir):

--- a/profit/run/local.py
+++ b/profit/run/local.py
@@ -11,6 +11,8 @@ from time import sleep
 import logging
 import numpy as np
 import os
+import shutil
+import sys
 from shutil import rmtree
 import json
 
@@ -22,12 +24,35 @@ from .worker import Worker
 # === Local Runner === #
 
 
+def available_cpus():
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return os.cpu_count() or 1
+
+
+def run_worker_in_directory(worker_config, interface_config, run_id, work_dir):
+    from profit.util import load_includes
+
+    if os.environ.get("PROFIT_INCLUDES"):
+        load_includes(json.loads(os.environ["PROFIT_INCLUDES"]))
+
+    return_dir = os.getcwd()
+    os.chdir(work_dir)
+    try:
+        worker = Worker.from_config(worker_config, interface_config, run_id)
+        worker.work()
+        worker.clean()
+    finally:
+        os.chdir(return_dir)
+
+
 class LocalRunner(Runner, label="local"):
     """start Workers locally via the shell"""
 
     def __init__(self, command="profit-worker", parallel="all", **kwargs):
         if parallel == "all":  # parallel: 'all' infers the number of available CPUs
-            parallel = len(os.sched_getaffinity(0))
+            parallel = available_cpus()
         self.command = command
         super().__init__(parallel=parallel, **kwargs)
 
@@ -49,14 +74,25 @@ class LocalRunner(Runner, label="local"):
         }
         return {**super().config, **config}  # super().config | config in python3.9
 
+    @property
+    def worker_command(self):
+        if self.command == "profit-worker" and shutil.which(self.command) is None:
+            return f'{sys.executable} -c "from profit.run.worker import main; main()"'
+        return self.command
+
     def spawn(self, params=None, wait=False):
         super().spawn(params, wait)
         env = os.environ.copy()
+        if self.worker_command != self.command:
+            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+            env["PYTHONPATH"] = os.pathsep.join(
+                p for p in [repo_root, env.get("PYTHONPATH")] if p
+            )
         env["PROFIT_RUN_ID"] = str(self.next_run_id)
         env["PROFIT_WORKER"] = json.dumps(self.worker)
         env["PROFIT_INTERFACE"] = json.dumps(self.interface.config)
         self.runs[self.next_run_id] = subprocess.Popen(
-            self.command, shell=True, env=env, cwd=self.work_dir
+            self.worker_command, shell=True, env=env, cwd=self.work_dir
         )
         if wait:
             self.wait(self.next_run_id)
@@ -80,21 +116,15 @@ class ForkRunner(Runner, label="fork"):
 
     def __init__(self, parallel="all", **kwargs):
         if parallel == "all":  # parallel: 'all' infers the number of available CPUs
-            parallel = len(os.sched_getaffinity(0))
+            parallel = available_cpus()
         super().__init__(parallel=parallel, **kwargs)
 
     def spawn(self, params=None, wait=False):
         super().spawn(params, wait)
-
-        def work():
-            with self.change_work_dir():
-                worker = Worker.from_config(
-                    self.worker, self.interface.config, self.next_run_id
-                )
-                worker.work()
-                worker.clean()
-
-        process = Process(target=work)
+        process = Process(
+            target=run_worker_in_directory,
+            args=(self.worker, self.interface.config, self.next_run_id, self.work_dir),
+        )
         self.runs[self.next_run_id] = process
         process.start()
         if wait:

--- a/profit/run/local.py
+++ b/profit/run/local.py
@@ -84,7 +84,9 @@ class LocalRunner(Runner, label="local"):
         super().spawn(params, wait)
         env = os.environ.copy()
         if self.worker_command != self.command:
-            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+            repo_root = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "..", "..")
+            )
             env["PYTHONPATH"] = os.pathsep.join(
                 p for p in [repo_root, env.get("PYTHONPATH")] if p
             )

--- a/tests/unit_tests/config/test_config.py
+++ b/tests/unit_tests/config/test_config.py
@@ -168,3 +168,18 @@ def test_default_values():
     assert config["fit"].get("surrogate") == defaults.fit["surrogate"]
     assert config["fit"].get("kernel") == defaults.fit_gaussian_process["kernel"]
     assert config["ui"].get("plot") is True
+
+
+def test_platform_run_defaults():
+    from profit import defaults
+
+    assert defaults.platform_run_defaults("nt") == {
+        "runner": "local",
+        "interface": "zeromq",
+        "worker": "command",
+    }
+    assert defaults.platform_run_defaults("posix") == {
+        "runner": "fork",
+        "interface": "memmap",
+        "worker": "command",
+    }

--- a/tests/unit_tests/run/test_command.py
+++ b/tests/unit_tests/run/test_command.py
@@ -169,6 +169,29 @@ def test_template(inputs, logger):
         preprocessor.post()
 
 
+def test_template_copies_symlink_targets_on_windows(tmp_path, monkeypatch):
+    from profit.run.command import TemplatePreprocessor
+
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    target = template_dir / "target.txt"
+    target.write_text("target data")
+    (template_dir / "link.txt").symlink_to(target)
+
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        TemplatePreprocessor,
+        "copy_symlinks_supported",
+        staticmethod(lambda: False),
+    )
+
+    TemplatePreprocessor.copy_template(template_dir, out_dir)
+
+    copied = out_dir / "link.txt"
+    assert copied.read_text() == "target data"
+    assert not copied.is_symlink()
+
+
 def test_command(logger, MockWorkerInterface, MockPreprocessor, MockPostprocessor):
     from profit.run.command import Worker, CommandWorker
 

--- a/tests/unit_tests/run/test_runner.py
+++ b/tests/unit_tests/run/test_runner.py
@@ -101,6 +101,29 @@ def test_register():
     assert Runner.labels == set(LABELS)
 
 
+def test_available_cpus_without_sched_getaffinity(monkeypatch):
+    from profit.run import local
+
+    monkeypatch.delattr(local.os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(local.os, "cpu_count", lambda: 3)
+
+    assert local.available_cpus() == 3
+
+
+def test_local_runner_falls_back_to_python_worker(monkeypatch):
+    from profit.run import local
+
+    monkeypatch.setattr(local.shutil, "which", lambda command: None)
+    monkeypatch.setattr(local.sys, "executable", "python")
+
+    runner = local.LocalRunner.__new__(local.LocalRunner)
+    runner.command = "profit-worker"
+
+    assert runner.worker_command == (
+        'python -c "from profit.run.worker import main; main()"'
+    )
+
+
 @pytest.mark.depends(
     on=[f"tests/unit_tests/run/test_interface.py::test_interface[{INTERFACE}]"]
 )


### PR DESCRIPTION
## Summary
- use `local` + `zeromq` as Windows run defaults instead of `fork` + `memmap`
- fall back from `os.sched_getaffinity` to `os.cpu_count` when CPU affinity is unavailable
- make forked workers spawn/forkserver-safe by using a top-level worker target and loading includes in the child
- fall back to a Python worker command when the `profit-worker` console script is not installed
- copy template symlink targets when symlink copying is not supported
- document the native Windows run configuration

Fixes #140

## Verification

### Test fails on main

```text
$ python -m pytest tests/unit_tests/run/test_runner.py::test_runner -q
_pickle.PicklingError: Can't pickle local object ... ForkRunner.spawn.<locals>.work
```

### Test passes after fix

```text
$ python -m pytest tests/unit_tests/config/test_config.py::test_platform_run_defaults tests/unit_tests/run/test_runner.py::test_available_cpus_without_sched_getaffinity tests/unit_tests/run/test_runner.py::test_local_runner_falls_back_to_python_worker tests/unit_tests/run/test_runner.py::test_runner tests/unit_tests/run/test_command.py::test_template_copies_symlink_targets_on_windows -q
6 passed, 1 skipped, 1 warning in 1.48s
```