### PR TITLE
Add conditional histogram UI view

### DIFF
--- a/doc/ui.rst
+++ b/doc/ui.rst
@@ -53,7 +53,7 @@ In this section of the layout the following three different types of options can
 Graph-type
 ----------
 
-There are four different graph-types available:
+There are five different graph-types available:
 
 * 1D (scatter & line)
     | input: x
@@ -67,8 +67,11 @@ There are four different graph-types available:
 * 3D (scatter & isosurface)
     | input: x | y | z
     | output: color
+* conditional histograms
+    | overlays marginal histograms for all numeric input and output variables
+    | filter-table ranges define the conditioned subset
 
-The four graph-types are shown below with sample data and a sample response model:
+The graph-types are shown below with sample data and a sample response model:
 
 .. figure:: pics/ex_1D_fit.png
   :width: 600
@@ -268,6 +271,12 @@ soon as an option is changed.
 In the 2D contour plot a fit surface of the 2D graph is shown from above. In addition all points in this area are displayed.
 Because all points (even the points with non-axis parameters far off the fit parameters) are displayed it is
 recommended to limit the span of the non-axis parameters via the **filter-table**.
+
+Conditional histograms
+----------------------
+The conditional histogram view overlays the marginal distribution of every numeric input and output variable with
+the subset selected by the active entries in the **filter-table**. This supports interactive exploration of
+high-dimensional data: restrict one or more input variables and inspect how the remaining marginals change.
 
 .. _filter options:
 Filter options

--- a/profit/ui/__init__.py
+++ b/profit/ui/__init__.py
@@ -1,2 +1,4 @@
-from . import app
-from .app import init_app
+def init_app(config):
+    from .app import init_app as create_app
+
+    return create_app(config)

--- a/profit/ui/app.py
+++ b/profit/ui/app.py
@@ -7,6 +7,7 @@ from math import log10
 import numpy as np
 from profit.util.file_handler import FileHandler
 from profit.sur import Surrogate
+from profit.ui.condhist import conditional_histogram_figure, structured_numeric_columns
 from matplotlib import cm as colormaps
 from matplotlib.colors import to_hex as color2hex
 
@@ -81,6 +82,7 @@ def init_app(config):
                                                     "2D",
                                                     "2D contour",
                                                     "3D",
+                                                    "conditional histograms",
                                                 ]
                                             ],
                                             value="1D",
@@ -1047,6 +1049,21 @@ def init_app(config):
                 hide,
                 show,
             )
+        if graph_type == "conditional histograms":
+            return (
+                hide,
+                hide,
+                hide,
+                hide,
+                hide,
+                hide,
+                hide,
+                1,
+                hide,
+                hide,
+                hide,
+                hide,
+            )
         else:
             return (
                 show,
@@ -1146,6 +1163,11 @@ def init_app(config):
             if filter_active != [[]]:
                 if filter_active[iteration] == ["act"]:
                     sel_y = sel_y_min & sel_y_max & sel_y
+        if graph_type == "conditional histograms":
+            return conditional_histogram_figure(
+                structured_numeric_columns(indata, outdata),
+                sel_y,
+            )
         if graph_type == "1D":
             fig = go.Figure(
                 data=[

--- a/profit/ui/condhist.py
+++ b/profit/ui/condhist.py
@@ -1,118 +1,85 @@
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
-from dash.dependencies import Input, Output
-from textwrap import dedent as d
+from math import ceil
 
-import pandas as pd
-
-# df = pd.read_hdf(r'..\examples\algae\MC\mc_out_allyears_sigma1.h5')
-df = pd.read_csv(
-    r"..\examples\algae\MC\mc_out_allyears_sigma1.dat", delim_whitespace=True
-)
-data = df.values
-param = data[:, 0:8]
+import numpy as np
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 
 
-def generate_table():
-    data = dict()
-    for l in range(4):
-        for k in range(2):
-            data[k + 2 * l] = [{"x": df.iloc[::100, k + 2 * l], "type": "histogram"}]
-    return html.Table(
-        [
-            html.Tr(
-                [
-                    html.Td(
-                        dcc.Graph(
-                            id="hist{}".format(k + 2 * l),
-                            figure={"data": data[k + 2 * l], "layout": {}},
-                        ),
-                        style={"width": "500px"},
-                    )
-                    for k in range(2)
-                ],
-                style={"height": "300px"},
-            )
-            for l in range(4)
-        ],
+def structured_numeric_columns(*arrays):
+    columns = {}
+    for array in arrays:
+        for name in array.dtype.names:
+            values = np.asarray(array[name]).reshape(-1)
+            if np.issubdtype(values.dtype, np.number):
+                key = name if name not in columns else f"output:{name}"
+                columns[key] = values
+    return columns
+
+
+def finite_values(values):
+    values = np.asarray(values).reshape(-1)
+    return values[np.isfinite(values)]
+
+
+def checked_mask(mask, size):
+    if mask is None:
+        return np.ones(size, dtype=bool)
+    mask = np.asarray(mask, dtype=bool).reshape(-1)
+    if len(mask) != size:
+        raise ValueError("mask length must match column length")
+    return mask
+
+
+def conditional_histogram_figure(columns, mask=None, bins=30, max_cols=3):
+    if not columns:
+        return go.Figure()
+
+    first = next(iter(columns.values()))
+    mask = checked_mask(mask, len(first))
+
+    names = list(columns)
+    ncols = min(max_cols, len(names))
+    nrows = ceil(len(names) / ncols)
+    fig = make_subplots(rows=nrows, cols=ncols, subplot_titles=names)
+
+    for index, name in enumerate(names):
+        values = np.asarray(columns[name]).reshape(-1)
+        all_values = finite_values(values)
+        selected_values = finite_values(values[mask])
+        row = index // ncols + 1
+        col = index % ncols + 1
+        showlegend = index == 0
+
+        fig.add_trace(
+            go.Histogram(
+                x=all_values,
+                nbinsx=bins,
+                histnorm="probability",
+                name="all",
+                marker_color="rgba(110, 110, 110, 0.35)",
+                showlegend=showlegend,
+            ),
+            row=row,
+            col=col,
+        )
+        fig.add_trace(
+            go.Histogram(
+                x=selected_values,
+                nbinsx=bins,
+                histnorm="probability",
+                name="filtered",
+                marker_color="rgba(28, 93, 153, 0.75)",
+                showlegend=showlegend,
+            ),
+            row=row,
+            col=col,
+        )
+
+    fig.update_layout(
+        title="Conditional marginal distributions",
+        barmode="overlay",
+        height=max(360, 300 * nrows),
+        margin=dict(l=50, r=20, t=70, b=45),
     )
-
-
-external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
-
-app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
-
-app.layout = html.Div(
-    children=[
-        html.H1(children="Conditional probability distributions"),
-        html.Div(
-            [
-                dcc.Markdown(
-                    d(
-                        """
-            **Click** on bars in one histogram to plot conditional
-            probability distribution for other variables.
-        """
-                    )
-                ),
-                html.Button("Reset", id="reset", n_clicks_timestamp=0),
-                # html.Pre(id='click-data'),
-            ]
-        ),
-        generate_table(),
-    ]
-)
-
-# @app.callback(
-#    Output('click-data', 'children'),
-#    [Input('hist0', 'clickData')])
-# def display_click_data(clickData):
-# return json.dumps(clickData['points'][0], indent=2)
-#    try:
-#        return json.dumps(clickData['points'][0]['binNumber'])
-#    except:
-#        return 0
-
-
-def gen_callback(k):
-    from numpy import array
-
-    def update_figure(*args):
-        defaultdata = {"data": [{"x": df.iloc[::100, k], "type": "histogram"}]}
-
-        # Find out who triggered the callback,
-        # see https://github.com/plotly/dash/issues/291
-        ctx = dash.callback_context
-
-        # Update was not triggered at all
-        if not ctx.triggered:
-            return defaultdata
-        trigger = ctx.triggered[0]
-
-        # Reset button triggered update
-        if trigger["prop_id"] == "reset.n_clicks":
-            return defaultdata
-
-        # Other component triggered update
-        try:
-            reducedset = array(trigger["value"]["points"][0]["pointNumbers"])
-        except:
-            return defaultdata
-        return {"data": [{"x": df.iloc[reducedset, k], "type": "histogram"}]}
-
-    return update_figure
-
-
-for k in range(8):
-    app.callback(
-        output=Output("hist{}".format(k), "figure"),
-        inputs=(
-            [Input("hist{}".format(l), "clickData") for l in range(8)]
-            + [Input("reset", "n_clicks")]
-        ),
-    )(gen_callback(k))
-
-
-if __name__ == "__main__":
-    app.run_server(debug=True, host="0.0.0.0")
+    fig.update_yaxes(title_text="probability")
+    return fig

--- a/tests/unit_tests/ui/test_condhist.py
+++ b/tests/unit_tests/ui/test_condhist.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+from profit.ui.condhist import (
+    checked_mask,
+    conditional_histogram_figure,
+    finite_values,
+    structured_numeric_columns,
+)
+
+
+def test_structured_numeric_columns_keeps_numeric_fields_only():
+    data = np.array(
+        [(1.0, 2, "a"), (3.0, 4, "b")],
+        dtype=[("x", "f8"), ("count", "i8"), ("label", "U1")],
+    )
+
+    columns = structured_numeric_columns(data)
+
+    assert list(columns) == ["x", "count"]
+    np.testing.assert_array_equal(columns["x"], np.array([1.0, 3.0]))
+    np.testing.assert_array_equal(columns["count"], np.array([2, 4]))
+
+
+def test_checked_mask_rejects_wrong_length():
+    with pytest.raises(ValueError, match="mask length"):
+        checked_mask([True, False], 3)
+
+
+def test_finite_values_removes_nan_and_inf():
+    values = finite_values([1.0, np.nan, np.inf, -np.inf, 2.0])
+
+    np.testing.assert_array_equal(values, np.array([1.0, 2.0]))
+
+
+def test_conditional_histogram_overlays_all_and_filtered_samples():
+    columns = {
+        "x": np.array([0.0, 1.0, 2.0, 3.0]),
+        "y": np.array([10.0, 11.0, 12.0, 13.0]),
+    }
+    mask = np.array([False, True, True, False])
+
+    fig = conditional_histogram_figure(columns, mask, bins=2, max_cols=2)
+
+    assert len(fig.data) == 4
+    assert fig.data[0].name == "all"
+    assert fig.data[1].name == "filtered"
+    np.testing.assert_array_equal(fig.data[1].x, np.array([1.0, 2.0]))


### PR DESCRIPTION
Fixes #22.

## Summary
- replace the old hardcoded conditional histogram prototype with reusable Plotly helpers
- add a `conditional histograms` graph type to the main Dash UI
- reuse existing filter-table ranges to overlay filtered marginals against all samples
- make `profit.ui` import lazy so non-Dash helper modules do not require Dash at import time
- document the new UI graph type

## Verification
- `python -m pytest tests/unit_tests/ui/test_condhist.py -q`
  - result: `4 passed in 0.44s`
- `python - <<'PY' ... import profit.ui as ui ... PY`
  - result: `True`
- `python -m compileall -q profit/ui/app.py profit/ui/condhist.py profit/ui/__init__.py tests/unit_tests/ui/test_condhist.py`
  - result: passed with no output

Note: this container does not currently have the declared `dash` runtime package installed, so the focused tests cover the pure histogram logic and lazy package import without launching the Dash server.